### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/lamp-application-requirements-status/lamp-app-v11/architecture_interactive.js
+++ b/lamp-application-requirements-status/lamp-app-v11/architecture_interactive.js
@@ -93,15 +93,24 @@ document.addEventListener('DOMContentLoaded', function() {
                 // Add detail popup effect
                 const detail = document.createElement('div');
                 detail.className = 'req-detail-popup';
-                detail.innerHTML = `
-                    <div class="popup-content">
-                        <h4>Requirement ${this.querySelector('.req-letter')?.textContent ?? ''}</h4>
-                        <p><strong>Service:</strong> ${this.querySelector('.req-name')?.textContent ?? ''}</p>
-                        <p><strong>Status:</strong> ${this.querySelector('.req-status')?.textContent ?? ''}</p>
-                        <p><strong>Implementation:</strong> Fully deployed and operational in AWS environment</p>
-                        <button class="close-popup">×</button>
-                    </div>
-                `;
+                // Utility function to escape HTML special characters
+                const escapeHTML = (str) => str.replace(/[&<>"']/g, (char) => ({
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                   "'": '&#39;',
+               }[char]));
+
+               detail.innerHTML = `
+                   <div class="popup-content">
+                       <h4>Requirement ${escapeHTML(this.querySelector('.req-letter')?.textContent ?? '')}</h4>
+                       <p><strong>Service:</strong> ${escapeHTML(this.querySelector('.req-name')?.textContent ?? '')}</p>
+                       <p><strong>Status:</strong> ${escapeHTML(this.querySelector('.req-status')?.textContent ?? '')}</p>
+                       <p><strong>Implementation:</strong> Fully deployed and operational in AWS environment</p>
+                       <button class="close-popup">×</button>
+                   </div>
+               `;
                 detail.style.cssText = `
                     position: fixed;
                     top: 50%;


### PR DESCRIPTION
Potential fix for [https://github.com/syed-reza98/lamp-app/security/code-scanning/1](https://github.com/syed-reza98/lamp-app/security/code-scanning/1)

To fix the issue, we need to ensure that any text extracted from the DOM and inserted into the `innerHTML` property is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using a utility function to escape special HTML characters (`<`, `>`, `&`, `"`, `'`) in the interpolated values. The escaped text can then be safely inserted into the DOM.

Steps to fix:
1. Create a utility function `escapeHTML` to escape special HTML characters.
2. Use this function to sanitize the values of `this.querySelector('.req-letter')?.textContent`, `this.querySelector('.req-name')?.textContent`, and `this.querySelector('.req-status')?.textContent` before including them in the `innerHTML` string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
